### PR TITLE
修改request data中amount的值类型

### DIFF
--- a/example/demoapp/ViewController.mm
+++ b/example/demoapp/ViewController.mm
@@ -182,13 +182,13 @@
     if (amount == 0) {
         return;
     }
-    NSString *amountStr = [NSString stringWithFormat:@"%lld", amount];
+//    NSString *amountStr = [NSString stringWithFormat:@"%lld", amount];
     NSURL* url = [NSURL URLWithString:kUrl];
     NSMutableURLRequest * postRequest=[NSMutableURLRequest requestWithURL:url];
 
     NSDictionary* dict = @{
         @"channel" : self.channel,
-        @"amount"  : amountStr
+        @"amount"  : @(amount)
     };
     NSData* data = [NSJSONSerialization dataWithJSONObject:dict options:NSJSONWritingPrettyPrinted error:nil];
     NSString *bodyData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
原实现中amount的值是amountStr，序列化为json后，形如：
{
    "channel": "xxx",
    "amount": "1234"
}
这会导致server端解析失败，需要确保amount是数值类型。